### PR TITLE
Update paths to boxparser.py

### DIFF
--- a/doc/sphinx/sdaps.setup.rst
+++ b/doc/sphinx/sdaps.setup.rst
@@ -12,10 +12,10 @@ sdaps.setup.additionalparser module
     :undoc-members:
     :show-inheritance:
 
-sdaps.setup.boxesparser module
+sdaps.setupodt.boxesparser module
 ------------------------------
 
-.. automodule:: sdaps.setup.boxesparser
+.. automodule:: sdaps.setupodt.boxesparser
     :members:
     :undoc-members:
     :show-inheritance:
@@ -28,18 +28,18 @@ sdaps.setup.buddies module
     :undoc-members:
     :show-inheritance:
 
-sdaps.setup.metaparser module
+sdaps.setupodt.metaparser module
 -----------------------------
 
-.. automodule:: sdaps.setup.metaparser
+.. automodule:: sdaps.setupodt.metaparser
     :members:
     :undoc-members:
     :show-inheritance:
 
-sdaps.setup.qobjectsparser module
+sdaps.setupodt.qobjectsparser module
 ---------------------------------
 
-.. automodule:: sdaps.setup.qobjectsparser
+.. automodule:: sdaps.setupodt.qobjectsparser
     :members:
     :undoc-members:
     :show-inheritance:

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -35,7 +35,7 @@ sdaps/report/answers.py
 sdaps/report/__init__.py
 sdaps/setup/__init__.py
 sdaps/setup/buddies.py
-sdaps/setup/boxesparser.py
+sdaps/setupodt/boxesparser.py
 sdaps/stamp/__init__.py
 sdaps/stamp/generic.py
 sdaps/stamp/latex.py

--- a/po/ar.po
+++ b/po/ar.po
@@ -886,7 +886,7 @@ msgstr ""
 msgid "%(class)s %(l0)i.%(l1)i got not exactly one box."
 msgstr ""
 
-#: ../sdaps/setup/boxesparser.py:121 ../sdaps/setup/boxesparser.py:190
+#: ../sdaps/setupodt/boxesparser.py:121 ../sdaps/setupodt/boxesparser.py:190
 #, python-format
 msgid ""
 "Warning: Ignoring a box (page: %i, x: %.1f, y: %.1f, width: %.1f, height: "

--- a/po/de.po
+++ b/po/de.po
@@ -1016,7 +1016,7 @@ msgstr "%(class)s %(l0)i.%(l1)i hat nicht exakt zwei Antworten."
 msgid "%(class)s %(l0)i.%(l1)i got not exactly one box."
 msgstr "%(class)s %(l0)i.%(l1)i hat nicht exakt eine Box."
 
-#: ../sdaps/setup/boxesparser.py:121 ../sdaps/setup/boxesparser.py:190
+#: ../sdaps/setupodt/boxesparser.py:121 ../sdaps/setupodt/boxesparser.py:190
 #, python-format
 msgid ""
 "Warning: Ignoring a box (page: %i, x: %.1f, y: %.1f, width: %.1f, height: "

--- a/po/es.po
+++ b/po/es.po
@@ -982,7 +982,7 @@ msgstr ""
 msgid "%(class)s %(l0)i.%(l1)i got not exactly one box."
 msgstr ""
 
-#: ../sdaps/setup/boxesparser.py:121 ../sdaps/setup/boxesparser.py:190
+#: ../sdaps/setupodt/boxesparser.py:121 ../sdaps/setupodt/boxesparser.py:190
 #, python-format
 msgid ""
 "Warning: Ignoring a box (page: %i, x: %.1f, y: %.1f, width: %.1f, height: "

--- a/po/fi.po
+++ b/po/fi.po
@@ -873,7 +873,7 @@ msgstr ""
 msgid "%(class)s %(l0)i.%(l1)i got not exactly one box."
 msgstr ""
 
-#: ../sdaps/setup/boxesparser.py:121 ../sdaps/setup/boxesparser.py:190
+#: ../sdaps/setupodt/boxesparser.py:121 ../sdaps/setupodt/boxesparser.py:190
 #, python-format
 msgid ""
 "Warning: Ignoring a box (page: %i, x: %.1f, y: %.1f, width: %.1f, height: "

--- a/po/fr.po
+++ b/po/fr.po
@@ -877,7 +877,7 @@ msgstr ""
 msgid "%(class)s %(l0)i.%(l1)i got not exactly one box."
 msgstr ""
 
-#: ../sdaps/setup/boxesparser.py:121 ../sdaps/setup/boxesparser.py:190
+#: ../sdaps/setupodt/boxesparser.py:121 ../sdaps/setupodt/boxesparser.py:190
 #, python-format
 msgid ""
 "Warning: Ignoring a box (page: %i, x: %.1f, y: %.1f, width: %.1f, height: "

--- a/po/nl.po
+++ b/po/nl.po
@@ -873,7 +873,7 @@ msgstr ""
 msgid "%(class)s %(l0)i.%(l1)i got not exactly one box."
 msgstr ""
 
-#: ../sdaps/setup/boxesparser.py:121 ../sdaps/setup/boxesparser.py:190
+#: ../sdaps/setupodt/boxesparser.py:121 ../sdaps/setupodt/boxesparser.py:190
 #, python-format
 msgid ""
 "Warning: Ignoring a box (page: %i, x: %.1f, y: %.1f, width: %.1f, height: "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1022,7 +1022,7 @@ msgstr "%(class)s %(l0)i.%(l1)i não tem exatamente duas respostas."
 msgid "%(class)s %(l0)i.%(l1)i got not exactly one box."
 msgstr "%(class)s %(l0)i.%(l1)i não tem exatamente uma caixa."
 
-#: ../sdaps/setup/boxesparser.py:121 ../sdaps/setup/boxesparser.py:190
+#: ../sdaps/setupodt/boxesparser.py:121 ../sdaps/setupodt/boxesparser.py:190
 #, python-format
 msgid ""
 "Warning: Ignoring a box (page: %i, x: %.1f, y: %.1f, width: %.1f, height: "


### PR DESCRIPTION
When building sdaps, I received an error when trying to open boxparser.py

``` bash
xgettext: error while opening "./../sdaps/setup/boxesparser.py" for reading: No such file or directory
ERROR: xgettext failed to generate PO template file. Please consult
       error message above if there is any.
error: command 'intltool-update' failed with exit status 1
```

I noticed there was a small refactor not long ago so I updated the paths I could find and installation completed without problems.
