### PR TITLE
Fix setupodt on setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ the tools to later analyse the scanned data, and create a report.
                 'sdaps.report',
                 'sdaps.reporttex',
                 'sdaps.setup',
+                'sdaps.setupodt',
                 'sdaps.setuptex',
                 'sdaps.utils'
       ],


### PR DESCRIPTION
Resolve the error when running the "setup" (ImportError: cannot import name setupodt).
The error only occurs when running the installed version of SDAPS.
