### PR TITLE
één results in errors, changed it to een

### DIFF
--- a/tex/po/nl.po
+++ b/tex/po/nl.po
@@ -67,7 +67,7 @@ msgid ""
 "answer the mark that fits best."
 msgstr ""
 "Bij waarderingsvragen met een bereik (1--\\arabic{markcheckboxcount}) mag "
-"slechts één hokje worden aangekruist."
+"slechts een hokje worden aangekruist."
 
 #. LaTeX based report: Label for the number of people that answered
 #: ../tex_translations.in.h:20


### PR DESCRIPTION
 I have changed "één" into "een". The translation één gives errors. See the bug report, I have posted issue 70.