### PR TITLE
raise IOError if file does not exist

### DIFF
--- a/sdaps/utils/opencv.py
+++ b/sdaps/utils/opencv.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os.path
+import errno
 import cv2
 import numpy as np
 from sdaps import image
@@ -38,6 +40,9 @@ def iter_images_and_pages(images):
     loading method for those."""
 
     for filename in images:
+        if not os.path.exists(filename):
+            raise IOError(errno.ENOENT, _("File does not exist"), filename)
+
         pages = 1
         is_tiff = False
         is_pdf = False


### PR DESCRIPTION
The aim is to provide a more meaningful error message to the user if a file does not exist. Currently one ends up with 

`AttributeError: 'NoneType' object has no attribute 'shape'`

thrown in `sdaps/sdaps/utils/opencv.py`, line 184, in `ensure_orientation`.

