### PR TITLE
Make the build reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ class sdaps_build_i18n(build_i18n.build_i18n):
             f.write('%\n\n')
             f.write('\\ProvidesDictionary{translator-sdaps-dictionary}{%s}\n\n' % name)
 
-            for key in keys:
+            for key in sorted(keys):
                 if lang is not None:
                     k = "%s[%s]" % (key, lang)
                 else:


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that sdaps could not be built reproducibly.

This is because `setup.py` iterates over the keys of a dictionary (to generate translations), an operation which, in Python, is nondeterministic.

This was originally filed in Debian as [#939549](https://bugs.debian.org/939549).