### PR TITLE
Adjustable corners and re-recognition

### DIFF
--- a/sdaps/gui/__init__.py
+++ b/sdaps/gui/__init__.py
@@ -35,6 +35,7 @@ import signal
 
 from sdaps import model
 from sdaps import surface
+from sdaps import recognize
 from sdaps import clifilter
 from sdaps import defs
 from sdaps import paths
@@ -393,6 +394,13 @@ class MainWindow(object):
             self._window.unfullscreen()
         else:
             self._window.fullscreen()
+        return True
+
+    def run_recognition(self, *args):
+        self.provider.survey.questionnaire.recognize.recognize(skip_identify=True,
+                                                               image=self.provider.image)
+        # We need to re-load the page as it gets cleared
+        self.provider.image.surface.load_rgb()
         return True
 
     def save_project(self, *args):

--- a/sdaps/gui/buddies.py
+++ b/sdaps/gui/buddies.py
@@ -71,7 +71,7 @@ class Questionnaire(model.buddy.Buddy, metaclass=model.buddy.Register):
     name = 'gui'
     obj_class = model.questionnaire.Questionnaire
 
-    def draw(self, cr, page_number):
+    def draw(self, cr, _image):
         # Draw an outline for the content area
         cr.save()
         cr.set_source_rgba(1.0, 0.0, 0.0, 0.6)
@@ -83,18 +83,18 @@ class Questionnaire(model.buddy.Buddy, metaclass=model.buddy.Register):
         cr.restore()
 
         for qobject in self.obj.qobjects:
-            qobject.gui.draw(cr, page_number)
+            qobject.gui.draw(cr, _image.page_number)
 
-    def find_box(self, page_number, x, y):
+    def find_box(self, _image, x, y):
         for qobject in self.obj.qobjects:
-            result = qobject.gui.find_box(page_number, x, y)
+            result = qobject.gui.find_box(_image.page_number, x, y)
             if result:
                 return result
         return None
 
-    def find_edge(self, page_number, x, y, tollerance_x, tollerance_y):
+    def find_edge(self, _image, x, y, tollerance_x, tollerance_y):
         for qobject in self.obj.qobjects:
-            result = qobject.gui.find_edge(page_number, x, y, tollerance_x, tollerance_y)
+            result = qobject.gui.find_edge(_image.page_number, x, y, tollerance_x, tollerance_y)
             if result:
                 return result
         return None

--- a/sdaps/gui/main_window.ui
+++ b/sdaps/gui/main_window.ui
@@ -260,6 +260,20 @@
               </packing>
             </child>
             <child>
+              <object class="GtkToolButton" id="recognize_toolbutton">
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="use_underline">True</property>
+                <property name="label" translatable="yes">Recognize Page</property>
+                <signal name="clicked" handler="run_recognition" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkSeparatorToolItem" id="toolbutton7">
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>

--- a/sdaps/gui/sheet_widget.py
+++ b/sdaps/gui/sheet_widget.py
@@ -146,7 +146,7 @@ class SheetWidget(Gtk.DrawingArea, Gtk.Scrollable):
 
         if event.button == 3:
             # Give the corresponding widget the focus.
-            box = self.provider.survey.questionnaire.gui.find_box(self.provider.image.page_number, mm_x, mm_y)
+            box = self.provider.survey.questionnaire.gui.find_box(self.provider.image, mm_x, mm_y)
             if hasattr(box, "widget"):
                 box.widget.focus()
 
@@ -157,7 +157,7 @@ class SheetWidget(Gtk.DrawingArea, Gtk.Scrollable):
 
         # Look for edges to drag first(on a 4x4px target)
         tollerance_x, tollerance_y = self._widget_to_mm_matrix.transform_distance(4.0, 4.0)
-        result = self.provider.survey.questionnaire.gui.find_edge(self.provider.image.page_number, mm_x, mm_y,
+        result = self.provider.survey.questionnaire.gui.find_edge(self.provider.image, mm_x, mm_y,
                                                                   tollerance_x, tollerance_y)
         if result:
             self._edge_drag_active = True
@@ -165,7 +165,7 @@ class SheetWidget(Gtk.DrawingArea, Gtk.Scrollable):
             self._edge_drag_data = result[1]
             return True
 
-        box = self.provider.survey.questionnaire.gui.find_box(self.provider.image.page_number, mm_x, mm_y)
+        box = self.provider.survey.questionnaire.gui.find_box(self.provider.image, mm_x, mm_y)
 
         if box is not None:
             box.data.state = not box.data.state
@@ -284,7 +284,7 @@ class SheetWidget(Gtk.DrawingArea, Gtk.Scrollable):
         cr.transform(self._mm_to_widget_matrix)
 
         # Draw the overlay stuff.
-        self.provider.survey.questionnaire.gui.draw(cr, self.provider.image.page_number)
+        self.provider.survey.questionnaire.gui.draw(cr, self.provider.image)
 
         def inner_box(cr, x, y, width, height):
             line_width = cr.get_line_width()

--- a/sdaps/gui/sheet_widget.py
+++ b/sdaps/gui/sheet_widget.py
@@ -160,6 +160,7 @@ class SheetWidget(Gtk.DrawingArea, Gtk.Scrollable):
         result = self.provider.survey.questionnaire.gui.find_edge(self.provider.image, mm_x, mm_y,
                                                                   tollerance_x, tollerance_y)
         if result:
+            self.queue_draw()
             self._edge_drag_active = True
             self._edge_drag_obj = result[0]
             self._edge_drag_data = result[1]

--- a/sdaps/gui/sheet_widget.py
+++ b/sdaps/gui/sheet_widget.py
@@ -74,6 +74,11 @@ class SheetWidget(Gtk.DrawingArea, Gtk.Scrollable):
         self.queue_draw()
 
     def partial_update(self, questionnaire, qobj, obj, name, old_value):
+        if qobj is None and name == "raw_matrix":
+            self._update_matrices()
+            self.queue_draw()
+            return
+
         if not isinstance(obj, model.data.Box):
             return
 

--- a/sdaps/recognize/buddies.py
+++ b/sdaps/recognize/buddies.py
@@ -41,6 +41,10 @@ class Sheet(model.buddy.Buddy, metaclass=model.buddy.Register):
     name = 'recognize'
     obj_class = model.sheet.Sheet
 
+    def __init__(self, *args):
+        model.buddy.Buddy.__init__(self, *args)
+        self.filter_image = None
+
     def recognize(self):
         global warned_multipage_not_correctly_scanned
 
@@ -306,6 +310,12 @@ class Sheet(model.buddy.Buddy, metaclass=model.buddy.Register):
 
             i += 2
 
+    def get_page_image(self, page_number):
+        img = self.obj.get_page_image(page_number)
+        if self.filter_image is not None:
+            return img if img == self.filter_image else None
+        return img
+
 
 class Image(model.buddy.Buddy, metaclass=model.buddy.Register):
 
@@ -553,7 +563,7 @@ class Checkbox(Box, metaclass=model.buddy.Register):
     obj_class = model.questionnaire.Checkbox
 
     def prepare_mask(self):
-        img = self.obj.sheet.get_page_image(self.obj.page_number)
+        img = self.obj.sheet.recognize.get_page_image(self.obj.page_number)
         width, height = self.obj.width, self.obj.height
         line_width = self.obj.lw
 
@@ -632,7 +642,7 @@ class Checkbox(Box, metaclass=model.buddy.Register):
 
 
     def recognize(self):
-        img = self.obj.sheet.get_page_image(self.obj.page_number)
+        img = self.obj.sheet.recognize.get_page_image(self.obj.page_number)
 
         if img is None or img.recognize.matrix is None:
             return
@@ -837,7 +847,7 @@ class Textbox(Box, metaclass=model.buddy.Register):
                     yield x, y
 
         bbox = None
-        img = self.obj.sheet.get_page_image(self.obj.page_number)
+        img = self.obj.sheet.recognize.get_page_image(self.obj.page_number)
 
         if img is None or img.recognize.matrix is None:
             return
@@ -904,7 +914,7 @@ class Codebox(Textbox, metaclass=model.buddy.Register):
     obj_class = model.questionnaire.Codebox
 
     def recognize(self):
-        img = self.obj.sheet.get_page_image(self.obj.page_number)
+        img = self.obj.sheet.recognize.get_page_image(self.obj.page_number)
 
         if img is None or img.recognize.matrix is None:
             return

--- a/sdaps/recognize/buddies.py
+++ b/sdaps/recognize/buddies.py
@@ -467,6 +467,13 @@ class Questionnaire(model.buddy.Buddy, metaclass=model.buddy.Register):
         try:
             self.obj.sheet.recognize.recognize()
             result = True
+
+            # Mark sheet as invalid if any page is missing,
+            for page in range(self.obj.page_count):
+                img = self.obj.sheet.get_page_image(page + 1)
+
+                if img is None or img.recognize.matrix is None:
+                    self.obj.sheet.valid = False
         except RecognitionError:
             self.obj.sheet.quality = 0
             result = False
@@ -628,7 +635,6 @@ class Checkbox(Box, metaclass=model.buddy.Register):
         img = self.obj.sheet.get_page_image(self.obj.page_number)
 
         if img is None or img.recognize.matrix is None:
-            self.obj.sheet.valid = 0
             return
 
         surf, xoff, yoff = self.get_outline_mask()
@@ -834,7 +840,6 @@ class Textbox(Box, metaclass=model.buddy.Register):
         img = self.obj.sheet.get_page_image(self.obj.page_number)
 
         if img is None or img.recognize.matrix is None:
-            self.obj.sheet.valid = 0
             return
 
         x = self.obj.x
@@ -902,7 +907,6 @@ class Codebox(Textbox, metaclass=model.buddy.Register):
         img = self.obj.sheet.get_page_image(self.obj.page_number)
 
         if img is None or img.recognize.matrix is None:
-            self.obj.sheet.valid = 0
             return
 
         x = self.obj.x

--- a/sdaps/recognize/buddies.py
+++ b/sdaps/recognize/buddies.py
@@ -494,13 +494,26 @@ class Questionnaire(model.buddy.Buddy, metaclass=model.buddy.Register):
 
         return result
 
-    def recognize(self):
+    def recognize(self, skip_identify=False, image=None):
         # recognize image
-        res = self.identify(clean=False)
+        if not skip_identify:
+            assert image is None
+            res = self.identify(clean=False)
+        elif image is None:
+            for img in self.obj.images:
+                if not img.ignored:
+                    img.surface.load()
+            res = True
+        else:
+            image.surface.load()
+            res = True
+
         if res:
             # iterate over qobjects
+            self.obj.sheet.recognize.filter_image = image
             for qobject in self.obj.qobjects:
                 qobject.recognize.recognize()
+            self.obj.sheet.recognize.filter_image = None
 
             quality = 1
             for qobject in self.obj.qobjects:


### PR DESCRIPTION
Fixes #194.

One more thing we might want to do is resetting the x/y location of all boxes on the page as soon as the matrix is manually adjusted. However, this is a bit of a corner case, because the feature is only useful when recognition was impossible to begin with and then no locations will be set anyway.