### PR TITLE
Resolve potential symlink before looking for _build folder

### DIFF
--- a/sdaps.py
+++ b/sdaps.py
@@ -22,7 +22,7 @@ import os
 import os.path
 
 bdir = '_build'
-bpath = os.getenv('BUILDDIR', os.path.join(os.path.dirname(__file__), '_build'))
+bpath = os.getenv('BUILDDIR', os.path.join(os.path.dirname(os.path.realpath(__file__)), '_build'))
 
 if not os.path.exists(bpath):
     sys.stderr.write(f'You need to build SDAPS into {bdir} or install it on the system\n\n')


### PR DESCRIPTION
Currently, running ``sdaps.py`` through a symlink (eg. in ``$HOME/.local/bin``) does not work, because it will look for its ``_build`` directory in the directory of the symlink, not in the directory the symlink points to.

This PR fixes that.